### PR TITLE
fix: fallback to references when object not found by id

### DIFF
--- a/src/sphinxnotes/any/domain.py
+++ b/src/sphinxnotes/any/domain.py
@@ -604,7 +604,19 @@ class PendingObject(PendingContext):
 
     @override
     def resolve(self) -> ResolvedContext:
-        _, _, obj = self.domain.objects[self.objtype, self.objid]
+        objid = self.objid
+        if (self.objtype, objid) not in self.domain.objects:
+            objids = set()
+            for objtype, objfield, objref in self.domain.references:
+                if objtype == self.objtype and objref == objid:
+                    objids.update(self.domain.references[objtype, objfield, objref])
+
+            if len(objids) >= 1:
+                objid = objids.pop()
+            else:
+                raise KeyError(f'Object not found: {(self.objtype, objid)}')
+
+        _, _, obj = self.domain.objects[self.objtype, objid]
         return obj
 
     def __hash__(self) -> int:

--- a/src/sphinxnotes/any/domain.py
+++ b/src/sphinxnotes/any/domain.py
@@ -652,14 +652,14 @@ class ObjEmbedDirective(BaseContextDirective):
 
     @override
     def current_template(self) -> Template:
+        debug = 'debug' in self.options
         if self.content:
-            return Template(
-                '\n'.join(self.content), Phase.Resolving, 'debug' in self.options
-            )
+            return Template('\n'.join(self.content), Phase.Resolving, debug)
 
         domain, objtype = self.get_domain_and_type()
         if tmpl := domain.templates[objtype].embed:
-            return tmpl
+            newtmpl = Template(tmpl.text, tmpl.phase, tmpl.debug or debug)
+            return newtmpl
 
         self.assert_has_content()
         assert False

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath('./src/sphinxnotes'))
+from any.domain import ObjDomain, PendingObject
+
+
+class TestPendingObjectResolve(unittest.TestCase):
+    def setUp(self):
+        self.domain = ObjDomain(MagicMock())
+        self.domain.data['objects'] = {}
+        self.domain.data['references'] = {}
+
+    def test_resolve_by_id(self):
+        obj = MagicMock()
+        self.domain.objects['foo', 'id1'] = ('doc1', 'anchor1', obj)
+
+        pending = PendingObject(domain=self.domain, objtype='foo', objid='id1')
+        result = pending.resolve()
+
+        self.assertIs(result, obj)
+
+    def test_resolve_by_reference(self):
+        obj = MagicMock()
+        self.domain.objects['foo', 'id1'] = ('doc1', 'anchor1', obj)
+        self.domain.references['foo', 'field1', 'ref1'] = {'id1'}
+
+        pending = PendingObject(domain=self.domain, objtype='foo', objid='ref1')
+        result = pending.resolve()
+
+        self.assertIs(result, obj)
+
+    def test_resolve_not_found(self):
+        self.domain.objects['foo', 'id1'] = ('doc1', 'anchor1', MagicMock())
+        self.domain.references['foo', 'field1', 'ref1'] = {'id1'}
+
+        pending = PendingObject(domain=self.domain, objtype='foo', objid='nonexistent')
+
+        with self.assertRaises(KeyError):
+            pending.resolve()
+
+    def test_resolve_multiple_references(self):
+        obj1 = MagicMock()
+        obj2 = MagicMock()
+        self.domain.objects['foo', 'id1'] = ('doc1', 'anchor1', obj1)
+        self.domain.objects['foo', 'id2'] = ('doc2', 'anchor2', obj2)
+        self.domain.references['foo', 'field1', 'ref1'] = {'id1', 'id2'}
+
+        pending = PendingObject(domain=self.domain, objtype='foo', objid='ref1')
+        result = pending.resolve()
+
+        self.assertIn(result, [obj1, obj2])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

When resolving a `PendingObject`, if the object is not found by `(objtype, objid)` in `objects`, fallback to searching `references` to find the object.

## Changes

- Modified `PendingObject.resolve()` in `domain.py` to:
  1. First try to find object by `(objtype, objid)` in `objects`
  2. If not found, search `references` using `(objtype, _, objid)` pattern
  3. Use the found `objid` to retrieve the object

- Added unit tests in `tests/test_domain.py` covering:
  - Resolving by ID
  - Resolving by reference
  - Multiple references
  - Not found scenario

Co-authored-by: MiniMax-M2.1 <minimax-cn-coding-plan@users.noreply.github.com>
Co-authored-by: opencode <opencode@users.noreply.github.com>