### PR TITLE
fix: Prevent PendingObject from pickling ObjDomain reference

### DIFF
--- a/src/sphinxnotes/any/domain.py
+++ b/src/sphinxnotes/any/domain.py
@@ -620,29 +620,30 @@ class AutoObjDefineDirective(ObjDefineDirective):
 
 @dataclass
 class PendingObject(UnresolvedContext):
-    domain: ObjDomain
+    domain_name: str
     objtype: str
     objid: str
 
     @override
-    def resolve(self) -> ResolvedContext:
+    def resolve(self, env: BuildEnvironment) -> ResolvedContext:
+        domain: ObjDomain = cast(ObjDomain, env.get_domain(self.domain_name))
         objid = self.objid
-        if (self.objtype, objid) not in self.domain.objects:
+        if (self.objtype, objid) not in domain.objects:
             objids = set()
-            for objtype, objfield, objref in self.domain.references:
+            for objtype, objfield, objref in domain.references:
                 if objtype == self.objtype and objref == objid:
-                    objids.update(self.domain.references[objtype, objfield, objref])
+                    objids.update(domain.references[objtype, objfield, objref])
 
             if len(objids) >= 1:
                 objid = objids.pop()
             else:
                 raise KeyError(f'Object not found: {(self.objtype, objid)}')
 
-        _, _, obj = self.domain.objects[self.objtype, objid]
+        _, _, obj = domain.objects[self.objtype, objid]
         return obj
 
     def __hash__(self) -> int:
-        return hash((self.domain.name, self.objtype, self.objid))
+        return hash((self.domain_name, self.objtype, self.objid))
 
 
 class ObjEmbedDirective(BaseContextDirective):
@@ -671,7 +672,7 @@ class ObjEmbedDirective(BaseContextDirective):
     def current_context(self) -> UnresolvedContext | ResolvedContext:
         domain, objtype = self.get_domain_and_type()
         objid = self.arguments[0]
-        return PendingObject(domain, objtype, objid)
+        return PendingObject(domain.name, objtype, objid)
 
     @override
     def current_template(self) -> Template:

--- a/src/sphinxnotes/any/domain.py
+++ b/src/sphinxnotes/any/domain.py
@@ -620,13 +620,13 @@ class AutoObjDefineDirective(ObjDefineDirective):
 
 @dataclass
 class PendingObject(UnresolvedContext):
-    domain_name: str
+    domain: str
     objtype: str
     objid: str
 
     @override
     def resolve(self, env: BuildEnvironment) -> ResolvedContext:
-        domain: ObjDomain = cast(ObjDomain, env.get_domain(self.domain_name))
+        domain: ObjDomain = cast(ObjDomain, env.get_domain(self.domain))
         objid = self.objid
         if (self.objtype, objid) not in domain.objects:
             objids = set()
@@ -643,7 +643,7 @@ class PendingObject(UnresolvedContext):
         return obj
 
     def __hash__(self) -> int:
-        return hash((self.domain_name, self.objtype, self.objid))
+        return hash((self.domain, self.objtype, self.objid))
 
 
 class ObjEmbedDirective(BaseContextDirective):

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -20,7 +20,7 @@ class TestPendingObjectResolve(unittest.TestCase):
         obj = MagicMock()
         self.domain.objects['foo', 'id1'] = ('doc1', 'anchor1', obj)
 
-        pending = PendingObject(domain_name='obj', objtype='foo', objid='id1')
+        pending = PendingObject(domain='obj', objtype='foo', objid='id1')
         result = pending.resolve(self.env)
 
         self.assertIs(result, obj)
@@ -30,7 +30,7 @@ class TestPendingObjectResolve(unittest.TestCase):
         self.domain.objects['foo', 'id1'] = ('doc1', 'anchor1', obj)
         self.domain.references['foo', 'field1', 'ref1'] = {'id1'}
 
-        pending = PendingObject(domain_name='obj', objtype='foo', objid='ref1')
+        pending = PendingObject(domain='obj', objtype='foo', objid='ref1')
         result = pending.resolve(self.env)
 
         self.assertIs(result, obj)
@@ -39,7 +39,7 @@ class TestPendingObjectResolve(unittest.TestCase):
         self.domain.objects['foo', 'id1'] = ('doc1', 'anchor1', MagicMock())
         self.domain.references['foo', 'field1', 'ref1'] = {'id1'}
 
-        pending = PendingObject(domain_name='obj', objtype='foo', objid='nonexistent')
+        pending = PendingObject(domain='obj', objtype='foo', objid='nonexistent')
 
         with self.assertRaises(KeyError):
             pending.resolve(self.env)
@@ -51,7 +51,7 @@ class TestPendingObjectResolve(unittest.TestCase):
         self.domain.objects['foo', 'id2'] = ('doc2', 'anchor2', obj2)
         self.domain.references['foo', 'field1', 'ref1'] = {'id1', 'id2'}
 
-        pending = PendingObject(domain_name='obj', objtype='foo', objid='ref1')
+        pending = PendingObject(domain='obj', objtype='foo', objid='ref1')
         result = pending.resolve(self.env)
 
         self.assertIn(result, [obj1, obj2])

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -9,16 +9,19 @@ from any.domain import ObjDomain, PendingObject
 
 class TestPendingObjectResolve(unittest.TestCase):
     def setUp(self):
+        self.env = MagicMock()
         self.domain = ObjDomain(MagicMock())
+        self.domain.name = 'obj'
         self.domain.data['objects'] = {}
         self.domain.data['references'] = {}
+        self.env.get_domain.return_value = self.domain
 
     def test_resolve_by_id(self):
         obj = MagicMock()
         self.domain.objects['foo', 'id1'] = ('doc1', 'anchor1', obj)
 
-        pending = PendingObject(domain=self.domain, objtype='foo', objid='id1')
-        result = pending.resolve()
+        pending = PendingObject(domain_name='obj', objtype='foo', objid='id1')
+        result = pending.resolve(self.env)
 
         self.assertIs(result, obj)
 
@@ -27,8 +30,8 @@ class TestPendingObjectResolve(unittest.TestCase):
         self.domain.objects['foo', 'id1'] = ('doc1', 'anchor1', obj)
         self.domain.references['foo', 'field1', 'ref1'] = {'id1'}
 
-        pending = PendingObject(domain=self.domain, objtype='foo', objid='ref1')
-        result = pending.resolve()
+        pending = PendingObject(domain_name='obj', objtype='foo', objid='ref1')
+        result = pending.resolve(self.env)
 
         self.assertIs(result, obj)
 
@@ -36,10 +39,10 @@ class TestPendingObjectResolve(unittest.TestCase):
         self.domain.objects['foo', 'id1'] = ('doc1', 'anchor1', MagicMock())
         self.domain.references['foo', 'field1', 'ref1'] = {'id1'}
 
-        pending = PendingObject(domain=self.domain, objtype='foo', objid='nonexistent')
+        pending = PendingObject(domain_name='obj', objtype='foo', objid='nonexistent')
 
         with self.assertRaises(KeyError):
-            pending.resolve()
+            pending.resolve(self.env)
 
     def test_resolve_multiple_references(self):
         obj1 = MagicMock()
@@ -48,8 +51,8 @@ class TestPendingObjectResolve(unittest.TestCase):
         self.domain.objects['foo', 'id2'] = ('doc2', 'anchor2', obj2)
         self.domain.references['foo', 'field1', 'ref1'] = {'id1', 'id2'}
 
-        pending = PendingObject(domain=self.domain, objtype='foo', objid='ref1')
-        result = pending.resolve()
+        pending = PendingObject(domain_name='obj', objtype='foo', objid='ref1')
+        result = pending.resolve(self.env)
 
         self.assertIn(result, [obj1, obj2])
 


### PR DESCRIPTION
## Summary
- Change `PendingObject.domain` from `ObjDomain` to `domain: str`
- Use `env.get_domain()` in `resolve()` to look up the domain at runtime
- This prevents pickle failures during doctree serialization

## Root Cause
`PendingObject` (an `UnresolvedContext`) stored a direct reference to
`ObjDomain`, which contains unpicklable local functions (XRefRole closures
in `_role_cache`). When Sphinx serializes the doctree via
`pickle.dump(doctree)`, it fails because these closures cannot be pickled.

## Dependencies
Requires https://github.com/sphinx-notes/render/pull/14 (adds `env`
parameter to `UnresolvedContext.resolve()`).